### PR TITLE
fix: set the configuration within the init call right away

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ VueMixpanel.install = function (Vue, { config, token }) {
   const defaultConfig = {}
   const endConfig = Object.assign(config, defaultConfig)
 
-  Vue.prototype.$mixpanel.init(token)
-  Vue.prototype.$mixpanel.set_config(endConfig)
+  Vue.prototype.$mixpanel.init(token, endConfig)
 }
 
 export default VueMixpanel


### PR DESCRIPTION
the init function can take token and config object the same time.

Especially in the case when an api_host is specified there are still requests to be observed which go to the default host.

see https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit